### PR TITLE
Added SNP data and SNP subjects export.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
     - cp .travis.BuildConfig.groovy ~/.grails/transmartConfig/BuildConfig.groovy
 
 install:
-    - maybe_build_maven_dep $(travis_get_owner)/${PREFIX}transmart-core-api core-api
+    - build_maven_dep $(travis_get_owner)/${PREFIX}transmart-core-api master core-api
     - make_inline_grails_dep $(travis_get_owner)/${PREFIX}transmart-core-db "$DEFAULT_BRANCH" core-db . transmart-core-db-tests
     - make_inline_grails_dep $(travis_get_owner)/${PREFIX}Rmodules "$DEFAULT_BRANCH" Rmodules
     - make_inline_grails_dep $(travis_get_owner)/${PREFIX}transmart-gwas "$DEFAULT_BRANCH" transmart-gwas

--- a/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
@@ -1,13 +1,18 @@
 package com.recomdata.transmart.data.export
 
 import org.transmartproject.core.dataquery.DataRow
+import org.transmartproject.core.dataquery.Patient
 import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
 import org.transmartproject.core.dataquery.highdim.assayconstraints.AssayConstraint
 import org.transmartproject.core.dataquery.highdim.projections.Projection
 import org.transmartproject.db.dataquery.highdim.assayconstraints.PlatformConstraint
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpSubjectSortedDef
+import org.transmartproject.export.HighDimColumnExporter
 import org.transmartproject.export.HighDimExporter
+import org.transmartproject.export.HighDimTabularResultExporter
 
 class HighDimExportService {
 
@@ -16,6 +21,46 @@ class HighDimExportService {
     
     // FIXME: jobResultsService lives in Rmodules, so this is probably not a dependency we should have here
     def jobResultsService
+
+    /**
+     * Limit to the number of elements in a query parameter, used in
+     * {@link #fetchSnpSubjectDataForAssays(Collection<Assay>)}.
+     * Prevents an error like "ORA-01795: maximum number of expressions in a list is 1000"
+     * The value should correspond to the database configuration and should probably
+     * move to a configuration file.
+     */
+    static final int max_query_param_elements = 500
+
+    /**
+     * Fetches SNP subject data (from {@link SnpSubjectSortedDef}) for the subjects
+     * in <code>assays</code>, using <code>patient.id</code> in the assay.
+     * The task is performed in chunks of {@link #max_query_param_elements} subjects at a time,
+     * to prevent overly long queries.
+     * @param assays A collection of assays, containing patient data.
+     * @return a map from patient id to subject data of type {@link SnpSubjectSortedDef}.
+     */
+    Map<Long, SnpSubjectSortedDef> fetchSnpSubjectDataForAssays(Collection<Assay> assays) {
+        List<Long> patientIds = assays*.patient.id
+        Map<Long, SnpSubjectSortedDef> subjectData = [:]
+        if (!patientIds.empty) {
+            def startTime = System.currentTimeMillis()
+            log.debug "Fetching subject data..."
+            int start = 0
+            while (start < patientIds.size()) {
+                int end = Math.min(start + max_query_param_elements, patientIds.size())
+                List<Long> cell = patientIds.subList(start, end);
+                log.debug "(size = ${patientIds.size()}, start = $start, end = $end)"
+                def subjects = SnpSubjectSortedDef.where { patient.id in cell }.list()
+                int count = subjects.size()
+                log.debug "(count = $count)"
+                subjects.each { SnpSubjectSortedDef subject -> subjectData[subject.patient.id] = subject }
+                start += count
+            }
+            log.debug "Fetching subject data took ${System.currentTimeMillis() - startTime} ms."
+        }
+        assert subjectData.size() == patientIds.size()
+        subjectData
+    }
 
     def exportHighDimData(Map args) {
         String jobName =                    args.jobName
@@ -49,24 +94,45 @@ class HighDimExportService {
 
         // Setup class to export the data
         HighDimExporter exporter = highDimExporterRegistry.getExporterForFormat( format )
-        Projection projection = dataTypeResource.createProjection( exporter.projection )
 
         File outputFile = new File(studyDir, dataType + '.' + format.toLowerCase() )
         String fileName = outputFile.getAbsolutePath()
 
-        // Retrieve the data itself
-        TabularResult<AssayColumn, DataRow<Map<String, String>>> tabularResult =
-                dataTypeResource.retrieveData(assayconstraints, [], projection)
-
-        // Start exporting
-        try {
-            outputFile.withOutputStream { outputStream ->
-                exporter.export tabularResult, projection, outputStream, { jobIsCancelled(jobName) }
+        if (exporter instanceof HighDimColumnExporter) {
+            exporter = exporter as HighDimColumnExporter
+            def startTime = System.currentTimeMillis()
+            log.debug "Fetching assays..."
+            Map<HighDimensionDataTypeResource, Collection<Assay>> assayMap = highDimensionResourceService.getSubResourcesAssayMultiMap(assayconstraints)
+            log.debug "Fetching assays took ${System.currentTimeMillis() - startTime} ms."
+            // for some reason, this dataTypeResourceKey is not the same as dataTypeResource:
+            def dataTypeResourceKey = assayMap.keySet().find { it.dataTypeName == dataTypeResource.dataTypeName }
+            Collection<Assay> assays = assayMap[dataTypeResourceKey]
+            Map subjectData = [:]
+            // Fetch SNP subject data for SNP exporters
+            if (exporter.isDataTypeSupported('snp_lz')) {
+                subjectData = fetchSnpSubjectDataForAssays(assays)
             }
-        } finally {
-            tabularResult.close()
-        }
+            // Start exporting column data
+            outputFile.withOutputStream { outputStream ->
+                exporter.export assays, subjectData, outputStream, { jobIsCancelled(jobName) }
+            }
+        } else {
+            exporter = exporter as HighDimTabularResultExporter
+            Projection projection = dataTypeResource.createProjection( exporter.projection )
 
+            // Retrieve the tabular data
+            TabularResult<AssayColumn, DataRow<Map<String, String>>> tabularResult =
+                    dataTypeResource.retrieveData(assayconstraints, [], projection)
+
+            // Start exporting tabular data
+            try {
+                outputFile.withOutputStream { outputStream ->
+                    exporter.export tabularResult, projection, outputStream, { jobIsCancelled(jobName) }
+                }
+            } finally {
+                tabularResult.close()
+            }
+        }
         return [outFile: fileName]
     }
 

--- a/src/groovy/org/transmartproject/export/GENExporter.groovy
+++ b/src/groovy/org/transmartproject/export/GENExporter.groovy
@@ -7,8 +7,8 @@ import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.assay.Assay
 import org.transmartproject.core.dataquery.highdim.AssayColumn;
 import org.transmartproject.core.dataquery.highdim.projections.Projection
-import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzCell
-import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzRow
+//import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzCell
+//import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzRow
 
 /**
  * Export for Single Nucleotide Polymorphism (SNP) data.
@@ -51,7 +51,7 @@ class GENExporter implements HighDimTabularResultExporter {
     }
 
     @Override
-    public void export(TabularResult<AssayColumn, SnpLzRow> data, Projection projection,
+    public void export(TabularResult /*<AssayColumn, SnpLzRow>*/ data, Projection projection,
             OutputStream outputStream) {
         export( data, projection, outputStream, { false } )
     }
@@ -59,7 +59,7 @@ class GENExporter implements HighDimTabularResultExporter {
     static final int default_distance = 0 // Genetic distance (morgans)
             
     @Override
-    public void export(TabularResult<AssayColumn, SnpLzRow> data, Projection projection,
+    public void export(TabularResult /*<AssayColumn, SnpLzRow>*/ data, Projection projection,
             OutputStream outputStream, Closure isCancelled) {
         log.info "Started exporting to ${format}..."
         def startTime = System.currentTimeMillis()
@@ -70,7 +70,7 @@ class GENExporter implements HighDimTabularResultExporter {
       
         def i = 1
         outputStream.withWriter( "UTF-8" ) { out ->
-            for (SnpLzRow row: data) {
+            for (/*SnpLzRow*/ Object row: data) {
                 if (isCancelled() ) {
                     return
                 }
@@ -89,7 +89,7 @@ class GENExporter implements HighDimTabularResultExporter {
                 out << ' '
                 out << row.a2
                 
-                for (SnpLzCell cell: row) { 
+                for (/*SnpLzCell*/ Object cell: row) { 
                     out << ' '
                     out << cell.probabilityA1A1
                     out << ' '

--- a/src/groovy/org/transmartproject/export/GENExporter.groovy
+++ b/src/groovy/org/transmartproject/export/GENExporter.groovy
@@ -1,0 +1,108 @@
+package org.transmartproject.export
+
+import javax.annotation.PostConstruct
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
+import org.transmartproject.core.dataquery.highdim.AssayColumn;
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzCell
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzRow
+
+/**
+ * Export for Single Nucleotide Polymorphism (SNP) data.
+ * Exports a genotype (GEN) file.
+ * @see {@link http://www.stats.ox.ac.uk/~marchini/software/gwas/file_format.html}
+ * for a description of the file format.
+ *  
+ * @author gijs@thehyve.nl
+ */
+class GENExporter implements HighDimTabularResultExporter {
+
+    @Autowired
+    HighDimExporterRegistry highDimExporterRegistry
+    
+    @PostConstruct
+    void init() {
+        this.highDimExporterRegistry.registerHighDimensionExporter(
+                format, this )
+    }
+    
+    @Override
+    public boolean isDataTypeSupported(String dataType) {
+        log.debug "Checking support for datatype ${dataType}"
+        dataType == "snp_lz"
+    }
+
+    @Override
+    public String getProjection() {
+        Projection.ALL_DATA_PROJECTION
+    }
+
+    @Override
+    public String getFormat() {
+        "GEN"
+    }
+
+    @Override
+    public String getDescription() {
+        "Genotype file (GEN)"
+    }
+
+    @Override
+    public void export(TabularResult<AssayColumn, SnpLzRow> data, Projection projection,
+            OutputStream outputStream) {
+        export( data, projection, outputStream, { false } )
+    }
+
+    static final int default_distance = 0 // Genetic distance (morgans)
+            
+    @Override
+    public void export(TabularResult<AssayColumn, SnpLzRow> data, Projection projection,
+            OutputStream outputStream, Closure isCancelled) {
+        log.info "Started exporting to ${format}..."
+        def startTime = System.currentTimeMillis()
+        
+        if (isCancelled() ) {
+            return
+        }
+      
+        def i = 1
+        outputStream.withWriter( "UTF-8" ) { out ->
+            for (SnpLzRow row: data) {
+                if (isCancelled() ) {
+                    return
+                }
+                
+                String chromosome = row.chromosome // the chromosome number is used as id
+                String rsId = row.snpName          // rs# or snp identifier
+                Integer position = row.position    // Base-pair position (bp units)
+                
+                out << chromosome
+                out << ' '
+                out << rsId        
+                out << ' '
+                out << position
+                out << ' '
+                out << row.a1
+                out << ' '
+                out << row.a2
+                
+                for (SnpLzCell cell: row) { 
+                    out << ' '
+                    out << cell.probabilityA1A1
+                    out << ' '
+                    out << cell.probabilityA1A2
+                    out << ' '
+                    out << cell.probabilityA2A2
+                }
+                out << '\n'
+                i++
+            }
+        }
+        
+        log.info("Exporting took ${System.currentTimeMillis() - startTime} ms.")
+    }
+
+}

--- a/src/groovy/org/transmartproject/export/HighDimColumnExporter.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimColumnExporter.groovy
@@ -1,0 +1,48 @@
+package org.transmartproject.export
+
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+
+/**
+ * Enables exporting column information for high dimensional data.
+ */
+interface HighDimColumnExporter extends HighDimExporter {
+    /**
+     * Determines whether a datatype is supported.
+     * @param dataType Name of the datatype.
+     * @return true if the datatype is supported by this exporter, false otherwise.
+     */
+    public boolean isDataTypeSupported( String dataType )
+
+    /**
+     * @return A short string describing the format that is 
+     *         produced by this exporter.
+     */
+    public String getFormat()
+
+    /**
+     * @return a longer human readable description for this exporter.
+     */
+    public String getDescription()
+
+    /**
+     * Exports column data to the outputStream.
+     * @param assays The assay data to be exported.
+     * @param subjectData Map from <code>assay.patient.id</code> to subject data.
+     * @param outputStream Stream to write the data to.
+     */
+    public void export( Collection<Assay> assays, Map subjectData, OutputStream outputStream )
+
+    /**
+     * Exports column data to the outputStream,
+     * although the export can be cancelled. Cancelling can be caused
+     * by the user or by some other process.
+     * @param assays The assay data to be exported
+     * @param subjectData Map from <code>assay.patient.id</code> to subject data. 
+     * @param outputStream Stream to write the data to.
+     * @param isCancelled Closure that returns true iff the export is cancelled.
+     */
+    public void export( Collection<Assay> assays, Map subjectData, OutputStream outputStream, Closure isCancelled )
+
+}

--- a/src/groovy/org/transmartproject/export/HighDimExporter.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimExporter.groovy
@@ -1,6 +1,7 @@
 package org.transmartproject.export
 
 import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
 import org.transmartproject.core.dataquery.highdim.projections.Projection
 
 /**
@@ -15,13 +16,6 @@ interface HighDimExporter {
     public boolean isDataTypeSupported( String dataType )
     
     /**
-     * Returns the projection name to be used for retrieving
-     * data from the database
-     * @return Projection name
-     */
-    public String getProjection()
-
-    /**
      * @return A short string describing the format that is 
      *         produced by this exporter
      */
@@ -31,24 +25,5 @@ interface HighDimExporter {
      * @return a longer human readable description for this exporter
      */
     public String getDescription()
-    
-    /**
-     * Exports the data in the TabularResult to the outputStream given
-     * @param data Data to be exported
-     * @param projection Projection that was used to retrieve the data
-     * @param outputStream Stream to write the data to
-     */
-    public void export( TabularResult data, Projection projection, OutputStream outputStream )
-    
-    /**
-     * Exports the data in the TabularResult to the outputStream given, 
-     * although the export can be cancelled. Cancelling can be caused
-     * by the user or by some other process.
-     * @param data Data to be exported
-     * @param projection Projection that was used to retrieve the data
-     * @param outputStream Stream to write the data to
-     * @param isCancelled Closure that returns true iff the export is cancelled
-     */
-    public void export( TabularResult data, Projection projection, OutputStream outputStream, Closure isCancelled )
 
 }

--- a/src/groovy/org/transmartproject/export/HighDimTabularResultExporter.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimTabularResultExporter.groovy
@@ -1,0 +1,38 @@
+package org.transmartproject.export
+
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+
+/**
+ * Enables exporting high dimensional data. 
+ */
+interface HighDimTabularResultExporter extends HighDimExporter {
+
+    /**
+     * Returns the projection name to be used for retrieving
+     * data from the database.
+     * @return Projection name.
+     */
+    public String getProjection()
+
+    /**
+     * Exports the data in the TabularResult to the outputStream given.
+     * @param data Data to be exported.
+     * @param projection Projection that was used to retrieve the data.
+     * @param outputStream Stream to write the data to.
+     */
+    public void export( TabularResult data, Projection projection, OutputStream outputStream )
+
+    /**
+     * Exports the data in the TabularResult to the outputStream given, 
+     * although the export can be cancelled. Cancelling can be caused
+     * by the user or by some other process.
+     * @param data Data to be exported.
+     * @param projection Projection that was used to retrieve the data.
+     * @param outputStream Stream to write the data to.
+     * @param isCancelled Closure that returns true iff the export is cancelled.
+     */
+    public void export( TabularResult data, Projection projection, OutputStream outputStream, Closure isCancelled )
+
+}

--- a/src/groovy/org/transmartproject/export/SAMPLEExporter.groovy
+++ b/src/groovy/org/transmartproject/export/SAMPLEExporter.groovy
@@ -1,0 +1,118 @@
+package org.transmartproject.export
+
+import java.util.Map;
+
+import javax.annotation.PostConstruct
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.transmartproject.core.dataquery.Patient
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpSubjectSortedDef
+
+/**
+ * Export for Single Nucleotide Polymorphism (SNP) data.
+ * Exports sample file.
+ * @see {@link http://www.stats.ox.ac.uk/~marchini/software/gwas/file_format.html}
+ * for a description of the file format.
+ * 
+ * @author gijs@thehyve.nl
+ */
+class SAMPLEExporter implements HighDimColumnExporter {
+
+    class SampleRow {
+        String id1
+        String id2
+    }
+    
+    @Autowired
+    HighDimExporterRegistry highDimExporterRegistry
+    
+    @PostConstruct
+    void init() {
+        this.highDimExporterRegistry.registerHighDimensionExporter(
+                format, this )
+    }
+    
+    @Override
+    public boolean isDataTypeSupported(String dataType) {
+        log.debug "Checking support for datatype ${dataType}"
+        dataType == "snp_lz"
+    }
+
+    @Override
+    public String getFormat() {
+        "SAMPLE"
+    }
+
+    @Override
+    public String getDescription() {
+        "Sample file (SAMPLE)"
+    }
+
+    @Override
+    public void export(Collection<Assay> assays, Map<Long, SnpSubjectSortedDef> subjectData,
+            OutputStream outputStream) {
+        export(assays, subjectData, outputStream, { false })
+    }
+
+    @Override
+    public void export(Collection<Assay> assays, Map<Long, SnpSubjectSortedDef> subjectData,
+            OutputStream outputStream, Closure isCancelled) {
+        log.info "Started exporting to ${format}..."
+        def startTime = System.currentTimeMillis()
+
+        if (isCancelled() ) {
+            return
+        }
+
+        outputStream.withWriter( "UTF-8" ) { out ->
+            exportHeader(out)
+            
+            for (AssayColumn assay: assays) {
+                if (isCancelled() ) {
+                    return
+                }
+
+                Patient patient = assay.patient
+                if (patient) {
+                    SnpSubjectSortedDef subject = subjectData[patient.id]
+                    def row = new SampleRow(
+                        id1: subject.subjectId, // column subject_id in deapp.de_snp_subject_sorted_def
+                        id2: patient.id // column patient_num in i2b2demodata.patient_dimension
+                    )
+                    exportSampleRow(row, out)
+                }
+            }
+        }
+        
+        log.info("Exporting took ${System.currentTimeMillis() - startTime} ms.")
+    }
+
+    protected void exportHeader(Writer out) {
+        // First header line, specifying column names. 
+        // The first three elements are mandatory.
+        out << 'ID_1 ID_2 missing\n'
+
+        // Second header line, specifying the column types.
+        // 0 is used for the first three columns. The following codes can be used 
+        // for additional columns:
+        //   D = Discrete covariate (coded using positive integers) 
+        //   C = Continuous covariates
+        //   P = Continuous Phenotype
+        //   B = Binary Phenotype (0 = Controls, 1 = Cases)
+        out << '0 0 0\n' 
+    }
+            
+    protected void exportSampleRow(SampleRow row, Writer out) {
+        out << row.id1
+        out << ' '
+        out << row.id2
+        out << ' '
+        out << 0
+        out << '\n'
+    }
+
+}

--- a/src/groovy/org/transmartproject/export/TFAMExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TFAMExporter.groovy
@@ -1,0 +1,139 @@
+package org.transmartproject.export
+
+import java.util.Map;
+
+import javax.annotation.PostConstruct
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.transmartproject.core.dataquery.Patient
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpSubjectSortedDef
+
+/**
+ * Export for Single Nucleotide Polymorphism (SNP) data.
+ * Exports individuals (TFAM) file.
+ * @see {@link http://pngu.mgh.harvard.edu/~purcell/plink/data.shtml}
+ * for a rather brief overview.
+ * 
+ * @author gijs@thehyve.nl
+ */
+class TFAMExporter implements HighDimColumnExporter {
+
+    enum Sex {
+        Male(1),
+        Female(2),
+        Unknown(0)
+        
+        int value
+        
+        Sex(value) {
+            this.value = value
+        }
+    }
+    
+    enum Phenotype {
+        Missing(-9),
+        Unaffected(0),
+        Affected(1)
+        
+        int value
+        
+        Phenotype(value) {
+            this.value = value
+        }
+    }
+
+    class TFAMRow {
+        String familyId
+        String individualId
+        String paternalId   
+        String maternalId
+        Sex sex
+        Phenotype phenotype
+    }
+    
+    @Autowired
+    HighDimExporterRegistry highDimExporterRegistry
+    
+    @PostConstruct
+    void init() {
+        this.highDimExporterRegistry.registerHighDimensionExporter(
+                format, this )
+    }
+    
+    @Override
+    public boolean isDataTypeSupported(String dataType) {
+        log.debug "Checking support for datatype ${dataType}"
+        dataType == "snp_lz"
+    }
+
+    @Override
+    public String getFormat() {
+        "TFAM"
+    }
+
+    @Override
+    public String getDescription() {
+        "Transposed individuals file (TFAM)"
+    }
+
+    @Override
+    public void export(Collection<Assay> assays, Map<Long, SnpSubjectSortedDef> subjectData,
+            OutputStream outputStream) {
+        export(assays, subjectData, outputStream, { false })
+    }
+            
+    @Override
+    public void export(Collection<Assay> assays, Map<Long, SnpSubjectSortedDef> subjectData,
+            OutputStream outputStream, Closure isCancelled) {
+        log.info "Started exporting to ${format}..."
+        def startTime = System.currentTimeMillis()
+        
+        if (isCancelled() ) {
+            return
+        }
+      
+        outputStream.withWriter( "UTF-8" ) { out ->
+            for (Assay assay: assays) {
+                if (isCancelled() ) {
+                    return
+                }
+                
+                Patient patient = assay.getPatient()
+                if (patient) {
+                    SnpSubjectSortedDef subject = subjectData[patient.getId()]
+                    def row = new TFAMRow(
+                        familyId: subject.subjectId,
+                        individualId: subject.subjectId,
+                        maternalId: 0,
+                        paternalId: 0,
+                        sex: Sex.Unknown,
+                        phenotype: Phenotype.Missing
+                    )
+                    exportTFAMRow(row, out)
+                }
+            }
+        }
+        
+        log.info("Exporting took ${System.currentTimeMillis() - startTime} ms.")
+    }
+
+    protected void exportTFAMRow(TFAMRow row, Writer out) {
+        out << row.familyId
+        out << ' '
+        out << row.individualId
+        out << ' '
+        out << row.paternalId
+        out << ' '
+        out << row.maternalId
+        out << ' '
+        out << row.sex.value
+        out << ' '
+        out << row.phenotype.value
+        out << '\n'
+    }
+
+}

--- a/src/groovy/org/transmartproject/export/TPEDExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TPEDExporter.groovy
@@ -1,0 +1,111 @@
+package org.transmartproject.export
+
+import javax.annotation.PostConstruct
+
+import org.apache.commons.lang.NotImplementedException
+import org.springframework.beans.factory.annotation.Autowired
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
+import org.transmartproject.core.dataquery.highdim.AssayColumn;
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzCell
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzRow
+
+/**
+ * Export for Single Nucleotide Polymorphism (SNP) data.
+ * Exports transposed pedigree (TPED) file.
+ * @see {@link http://pngu.mgh.harvard.edu/~purcell/plink/data.shtml}
+ * for a rather brief overview.
+ * 
+ * The exported genotypes are the most likely alleles. I.e., 
+ * for a SNP with A1 = 'C' and A2 = 'T', the probabilities of A1A1,
+ * A1A2 and A2A2 are used to export 'C C', 'C T', or 'T T'.
+ * If the probability triples only contains one 1 and two 0's, 
+ * the export is precise.
+ * 
+ * @author gijs@thehyve.nl
+ */
+class TPEDExporter implements HighDimTabularResultExporter {
+
+    @Autowired
+    HighDimExporterRegistry highDimExporterRegistry
+    
+    @PostConstruct
+    void init() {
+        this.highDimExporterRegistry.registerHighDimensionExporter(
+                format, this )
+    }
+    
+    @Override
+    public boolean isDataTypeSupported(String dataType) {
+        log.debug "Checking support for datatype ${dataType}"
+        dataType == "snp_lz"
+    }
+
+    @Override
+    public String getProjection() {
+        Projection.ALL_DATA_PROJECTION
+    }
+
+    @Override
+    public String getFormat() {
+        "TPED"
+    }
+
+    @Override
+    public String getDescription() {
+        "Transposed pedigree file (TPED)"
+    }
+
+    @Override
+    public void export(TabularResult<AssayColumn, SnpLzRow> data, Projection projection,
+            OutputStream outputStream) {
+        export( data, projection, outputStream, { false } )
+    }
+
+    static final int default_distance = 0 // Genetic distance (morgans)
+            
+    @Override
+    public void export(TabularResult<AssayColumn, SnpLzRow> data, Projection projection,
+            OutputStream outputStream, Closure isCancelled) {
+        log.info "Started exporting to ${format}..."
+        def startTime = System.currentTimeMillis()
+        
+        if (isCancelled() ) {
+            return
+        }
+      
+        def i = 1
+        outputStream.withWriter( "UTF-8" ) { out ->
+            for (SnpLzRow row: data) {
+                if (isCancelled() ) {
+                    return
+                }
+                
+                String chromosome = row.chromosome  // (1-22, X, Y or 0 if unplaced)
+                String snpId = row.snpName          // rs# or snp identifier
+                Integer position = row.position     // Base-pair position (bp units)
+                
+                out << chromosome
+                out << ' '
+                out << snpId        
+                out << ' '
+                out << default_distance
+                out << ' '
+                out << position
+                
+                for (SnpLzCell cell: row) {
+                    out << ' '
+                    out << cell.likelyAllele1   // most likely value for allele1
+                    out << ' '
+                    out << cell.likelyAllele2   // most likely value for allele2
+                }
+                out << '\n'
+                i++
+            }
+        }
+        
+        log.info("Exporting took ${System.currentTimeMillis() - startTime} ms.")
+    }
+
+}

--- a/src/groovy/org/transmartproject/export/TPEDExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TPEDExporter.groovy
@@ -8,8 +8,8 @@ import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.assay.Assay
 import org.transmartproject.core.dataquery.highdim.AssayColumn;
 import org.transmartproject.core.dataquery.highdim.projections.Projection
-import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzCell
-import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzRow
+//import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzCell
+//import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzRow
 
 /**
  * Export for Single Nucleotide Polymorphism (SNP) data.
@@ -58,7 +58,7 @@ class TPEDExporter implements HighDimTabularResultExporter {
     }
 
     @Override
-    public void export(TabularResult<AssayColumn, SnpLzRow> data, Projection projection,
+    public void export(TabularResult /*<AssayColumn, SnpLzRow>*/ data, Projection projection,
             OutputStream outputStream) {
         export( data, projection, outputStream, { false } )
     }
@@ -66,7 +66,7 @@ class TPEDExporter implements HighDimTabularResultExporter {
     static final int default_distance = 0 // Genetic distance (morgans)
             
     @Override
-    public void export(TabularResult<AssayColumn, SnpLzRow> data, Projection projection,
+    public void export(TabularResult /*<AssayColumn, SnpLzRow>*/ data, Projection projection,
             OutputStream outputStream, Closure isCancelled) {
         log.info "Started exporting to ${format}..."
         def startTime = System.currentTimeMillis()
@@ -77,7 +77,7 @@ class TPEDExporter implements HighDimTabularResultExporter {
       
         def i = 1
         outputStream.withWriter( "UTF-8" ) { out ->
-            for (SnpLzRow row: data) {
+            for (/*SnpLzRow*/ Object row: data) {
                 if (isCancelled() ) {
                     return
                 }
@@ -94,7 +94,7 @@ class TPEDExporter implements HighDimTabularResultExporter {
                 out << ' '
                 out << position
                 
-                for (SnpLzCell cell: row) {
+                for (/*SnpLzCell*/ Object cell: row) {
                     out << ' '
                     out << cell.likelyAllele1   // most likely value for allele1
                     out << ' '

--- a/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TabSeparatedExporter.groovy
@@ -1,17 +1,19 @@
 package org.transmartproject.export
 
+import javax.annotation.PostConstruct
+
+import org.apache.commons.lang.NotImplementedException
 import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.HighDimensionDataTypeResource
 import org.transmartproject.core.dataquery.highdim.HighDimensionResource
 import org.transmartproject.core.dataquery.highdim.projections.Projection
 import org.transmartproject.core.exceptions.NoSuchResourceException
 
-import javax.annotation.PostConstruct
-
-class TabSeparatedExporter implements HighDimExporter {
+class TabSeparatedExporter implements HighDimTabularResultExporter {
     final static String SEPARATOR = "\t"
 
     @Autowired

--- a/src/groovy/org/transmartproject/export/VCFExporter.groovy
+++ b/src/groovy/org/transmartproject/export/VCFExporter.groovy
@@ -1,16 +1,19 @@
 package org.transmartproject.export
 
 import grails.util.Metadata
+
+import javax.annotation.PostConstruct
+
+import org.apache.commons.lang.NotImplementedException
 import org.springframework.beans.factory.annotation.Autowired
 import org.transmartproject.core.dataquery.DataRow
 import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
 import org.transmartproject.core.dataquery.highdim.AssayColumn
 import org.transmartproject.core.dataquery.highdim.HighDimensionResource
 import org.transmartproject.core.dataquery.highdim.projections.Projection
 
-import javax.annotation.PostConstruct
-
-class VCFExporter implements HighDimExporter {
+class VCFExporter implements HighDimTabularResultExporter {
     /**
      * List of info fields that can be exported without any change.
      * This list should only include fields for which the value is the

--- a/test/unit/org/transmartproject/export/GENExporterTests.groovy
+++ b/test/unit/org/transmartproject/export/GENExporterTests.groovy
@@ -1,0 +1,93 @@
+package org.transmartproject.export
+
+import groovy.lang.Delegate;
+
+import org.apache.commons.logging.LogFactory
+import org.gmock.WithGMock
+import org.junit.Before
+import org.junit.Test
+import org.transmartproject.core.dataquery.DataRow
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+
+/**
+ * Tests for the GEN exporter in {@link GENExporter}
+ * 
+ * Generates mock data for the data types provided by {@link SnpLzModule}
+ * and tests if valid GEN output is written, i.e., one line per 
+ * Single Nucleotide Polymorphism (SNP). 
+ * The format has five columns for information about the SNP, and 
+ * per subject three probabilities: <code>probabilityA1A1</code>, 
+ * <code>probabilityA1A2</code> and <code>probabilityA1A1</code> respectively in {@link SnpLzCell}.
+ * 
+ * @author gijs@thehyve.nl
+ */
+@WithGMock
+class GENExporterTests {
+
+    private static final log = LogFactory.getLog(this)
+    
+    @Delegate
+    SNPMockDataHelper snpMockDataHelper
+    
+    GENExporter exporter
+    TabularResult tabularResult
+    Projection projection
+    
+    @Before
+    void before() {
+        snpMockDataHelper = new SNPMockDataHelper()
+        snpMockDataHelper.gMockController = $gmockController
+        
+        // Setup exporter
+        exporter = new GENExporter()
+    }
+    
+    @Test
+    void "test whether supported datatypes are recognized"() {
+        // Only SNP datatype is supported
+        assert exporter.isDataTypeSupported( "snp_lz" )
+        
+        assert !exporter.isDataTypeSupported( "other" )
+        assert !exporter.isDataTypeSupported( null )
+    }
+    
+    @Test
+    void "test whether a basic tabular result is exported properly"() {
+        tabularResult = createMockSnpLzTabularResult()
+        
+        // Create cohort projection, as that is used for exporting.
+        def projection = mock(Projection)
+        
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        
+        play {
+            exporter.export( tabularResult, projection, outputStream )
+            
+            // Assert we have at least some text, in UTF-8 encoding
+            String output = outputStream.toString("UTF-8")
+            assert output
+            
+            List lines = output.readLines()
+            
+            lines.each { String line -> 
+                log.debug "Line: " + line
+                def values = line.tokenize()
+                assert values.size() == 5 + 3 * subjectCount // five columns for SNP info + three probabilities per subject
+                def chromosome = values[0]
+                def snpId = values[1]
+                def position = values[2]
+                def a1 = values[3]
+                def a2 = values[4]
+                def snpKey = snpMockDataHelper.snpProperties.find { it.value.snpName == snpId }.key
+                snpMockDataHelper.cellData[snpKey].eachWithIndex { cell, i ->
+                    assert cell.probabilityA1A1 == Double.parseDouble(values[5 + i*3])
+                    assert cell.probabilityA1A2 == Double.parseDouble(values[5 + i*3 + 1])
+                    assert cell.probabilityA2A2 == Double.parseDouble(values[5 + i*3 + 2])
+                }
+            }
+        }
+    }
+
+}

--- a/test/unit/org/transmartproject/export/SAMPLEExporterTests.groovy
+++ b/test/unit/org/transmartproject/export/SAMPLEExporterTests.groovy
@@ -1,0 +1,99 @@
+package org.transmartproject.export
+
+import java.util.Map;
+
+import org.apache.commons.logging.LogFactory
+import org.gmock.WithGMock
+import org.junit.Before
+import org.junit.Test
+import org.transmartproject.core.dataquery.DataRow
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+
+/**
+ * Tests for the SAMPLE exporter in {@link SAMPLEExporter}
+ * 
+ * Generates mock data for the data types provided by {@link SnpSubjectModule}
+ * and tests if valid SAMPLE output is written, i.e., one line per subject.
+
+ * The format has three mandatory columns for subject information:
+ * <code>ID_1</code>, <code>ID_2</code> and <code>missing</code>.
+ * The first two lines are header lines.
+ * 
+ * @author gijs@thehyve.nl
+ */
+@WithGMock
+class SAMPLEExporterTests {
+
+    private static final log = LogFactory.getLog(this)
+    
+    @Delegate
+    SNPMockDataHelper snpMockDataHelper
+    
+    SAMPLEExporter exporter
+    TabularResult tabularResult
+    Map subjects
+    Projection projection
+    
+    Map<String, Map> snpProperties
+    Map<String, List> cellData
+    
+    @Before
+    void before() {
+        snpMockDataHelper = new SNPMockDataHelper()
+        snpMockDataHelper.gMockController = $gmockController
+        
+        // Setup exporter
+        exporter = new SAMPLEExporter()
+    }
+    
+    @Test
+    void "test whether supported datatypes are recognized"() {
+        // Only SNP datatype is supported
+        assert exporter.isDataTypeSupported( "snp_lz" )
+        
+        assert !exporter.isDataTypeSupported( "other" )
+        assert !exporter.isDataTypeSupported( null )
+    }
+    
+    @Test
+    void "test whether a basic tabular result is exported properly"() {
+        tabularResult = createMockSnpLzTabularResult()
+        subjects = createMockSubjectData()
+        
+        log.debug "subjects: $subjects"
+        
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        
+        play {
+            List<AssayColumn> assays = tabularResult.getIndicesList()
+            exporter.export( assays, subjects, outputStream )
+            
+            // Assert we have at least some text, in UTF-8 encoding
+            String output = outputStream.toString("UTF-8")
+            assert output
+            
+            List lines = output.readLines()
+            
+            assert lines.size() == 2 + subjectCount
+            
+            lines.eachWithIndex { String line, i ->
+                if (i < 2) {
+                    return // skip the two header lines
+                } 
+                log.debug "Line: " + line
+                def values = line.tokenize()
+                assert values.size() >= 3
+                def id1 = values[0]
+                def id2 = values[1]
+                def subject = subjectData[i-2]
+                // subjectId is used for the ID_1 field
+                assert subject.subjectId == id1
+                // patientNum is used for the ID_2 field
+                assert subject.subjectPosition == Integer.parseInt(id2)
+            }
+        }
+    }
+    
+}

--- a/test/unit/org/transmartproject/export/SNPMockDataHelper.groovy
+++ b/test/unit/org/transmartproject/export/SNPMockDataHelper.groovy
@@ -7,8 +7,8 @@ import org.transmartproject.core.dataquery.Patient
 import org.transmartproject.core.dataquery.TabularResult
 import org.transmartproject.core.dataquery.assay.Assay
 import org.transmartproject.core.dataquery.highdim.AssayColumn
-import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzCell
-import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzRow
+//import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzCell
+//import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzRow
 import org.transmartproject.db.dataquery.highdim.snp_lz.SnpSubjectSortedDef
 
 class SNPMockDataHelper extends MockTabularResultHelper {
@@ -131,16 +131,17 @@ class SNPMockDataHelper extends MockTabularResultHelper {
             Map<String,Object> snpProperties) {
             
         def cells = data.collect { assay, celldata ->
-            new SnpLzCell(
-                (double)celldata.probabilityA1A1,
-                (double)celldata.probabilityA1A2,
-                (double)celldata.probabilityA2A2,
-                (char)celldata.likelyAllele1,
-                (char)celldata.likelyAllele2,
-                (double)celldata.minorAlleleDose)
+            Object cell = mock(Object)
+            cell.probabilityA1A1.returns((double)celldata.probabilityA1A1).stub()
+            cell.probabilityA1A2.returns((double)celldata.probabilityA1A2).stub()
+            cell.probabilityA2A2.returns((double)celldata.probabilityA2A2).stub()
+            cell.likelyAllele1.returns((char)celldata.likelyAllele1).stub()
+            cell.likelyAllele2.returns((char)celldata.likelyAllele2).stub()
+            cell.minorAlleleDose.returns((double)celldata.minorAlleleDose).stub()
+            cell
         }
         
-        SnpLzRow row = mock(SnpLzRow)
+        DataRow row = mock(DataRow)
         row.snpName.returns(snpProperties.snpName).stub()
         row.chromosome.returns(snpProperties.chromosome).stub()
         row.position.returns(snpProperties.position).stub()

--- a/test/unit/org/transmartproject/export/SNPMockDataHelper.groovy
+++ b/test/unit/org/transmartproject/export/SNPMockDataHelper.groovy
@@ -1,0 +1,158 @@
+package org.transmartproject.export
+
+import grails.test.mixin.*
+
+import org.transmartproject.core.dataquery.DataRow
+import org.transmartproject.core.dataquery.Patient
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.assay.Assay
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzCell
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpLzRow
+import org.transmartproject.db.dataquery.highdim.snp_lz.SnpSubjectSortedDef
+
+class SNPMockDataHelper extends MockTabularResultHelper {
+
+    List<AssayColumn> sampleAssays
+    List<Map> subjectData
+    Map<String, Map> snpProperties
+    Map<String, List> cellData
+    
+    final int subjectCount = 2
+    
+    void generateSubjectData() {
+        this.sampleAssays = createSampleAssays(subjectCount)
+        def sampleCodes = sampleAssays*.sampleCode
+        
+        this.subjectData = [
+            [ "subjectId": sampleCodes[0], "subjectPosition": 1 ],
+            [ "subjectId": sampleCodes[1], "subjectPosition": 2 ]
+        ]
+    }
+    
+    Map createMockSubjectData() {
+        if (!subjectData) {
+            generateSubjectData()
+        }
+        Map subjects = [:]
+        for (Map data: subjectData) {
+            SnpSubjectSortedDef subject = mock(SnpSubjectSortedDef)
+            subject.patientPosition.returns(data.subjectPosition).stub()
+            subject.subjectId.returns(data.subjectId).stub()
+            def patient = patients[data.subjectPosition - 1]
+            subject.patient.returns(patient).stub()
+            subjects[new Long(data.subjectPosition)] = subject // assuming patient id == subjectPosition
+        }
+        return subjects
+    }
+    
+    TabularResult createMockSnpLzTabularResult() {
+        generateSubjectData()
+        
+        this.snpProperties = [
+            "row1": [ chromosome: 1, position: 100, snpName: "rs0010", a1: 'A', a2: 'T'],
+            "row2": [ chromosome: 1, position: 200, snpName: "rs1234", a1: 'C', a2: 'G'],
+            "row3": [ chromosome: 'X', position: 30, snpName: "rs9999", a1: 'G', a2: 'T'],
+        ]
+
+        this.cellData = [
+            "row1": [
+                [   probabilityA1A1: (double)1.0,
+                    probabilityA1A2: (double)0.0,
+                    probabilityA2A2: (double)0.0,
+                    likelyAllele1: 'A',
+                    likelyAllele2: 'A',
+                    minorAlleleDose: (double)0.0
+                ],
+                [   probabilityA1A1: (double)0.0,
+                    probabilityA1A2: (double)1.0,
+                    probabilityA2A2: (double)0.0,
+                    likelyAllele1: 'A',
+                    likelyAllele2: 'T',
+                    minorAlleleDose: (double)0.0
+                ],
+            ],
+            "row2": [
+                [   probabilityA1A1: (double)0.0,
+                    probabilityA1A2: (double)0.0,
+                    probabilityA2A2: (double)1.0,
+                    likelyAllele1: 'G',
+                    likelyAllele2: 'G',
+                    minorAlleleDose: (double)0.0
+                ],
+                [   probabilityA1A1: (double)0.0,
+                    probabilityA1A2: (double)1.0,
+                    probabilityA2A2: (double)0.0,
+                    likelyAllele1: 'C',
+                    likelyAllele2: 'G',
+                    minorAlleleDose: (double)0.0
+                ],
+            ],
+            "row3": [
+                [   probabilityA1A1: (double)1.0,
+                    probabilityA1A2: (double)0.0,
+                    probabilityA2A2: (double)0.0,
+                    likelyAllele1: 'G',
+                    likelyAllele2: 'T',
+                    minorAlleleDose: (double)0.0
+                ],
+                [   probabilityA1A1: (double)1.0,
+                    probabilityA1A2: (double)0.0,
+                    probabilityA2A2: (double)0.0,
+                    likelyAllele1: 'G',
+                    likelyAllele2: 'G',
+                    minorAlleleDose: (double)0.0
+                ],
+            ],
+        ]
+        
+        def iterator = cellData.collect { String label, List data ->
+            createSnpLzRowForAssays(sampleAssays, data, snpProperties[label])
+        }.iterator()
+                
+        TabularResult highDimResult = mock TabularResult
+        highDimResult.indicesList.returns(sampleAssays).stub()
+        highDimResult.getRows().returns(iterator).stub()
+        highDimResult.iterator().returns(iterator).stub()
+        
+        highDimResult
+    }
+    
+    DataRow createSnpLzRowForAssays(List<AssayColumn> assays,
+            List data,
+            Map<String,Object> snpProperties) {
+        createMockSnpLzRow(
+                dot(assays, data, {a, b -> [ a, b ]})
+                         .collectEntries(Closure.IDENTITY),
+                snpProperties)
+    }
+            
+    private DataRow<AssayColumn, Object> createMockSnpLzRow(Map<AssayColumn, Object> data,
+            Map<String,Object> snpProperties) {
+            
+        def cells = data.collect { assay, celldata ->
+            new SnpLzCell(
+                (double)celldata.probabilityA1A1,
+                (double)celldata.probabilityA1A2,
+                (double)celldata.probabilityA2A2,
+                (char)celldata.likelyAllele1,
+                (char)celldata.likelyAllele2,
+                (double)celldata.minorAlleleDose)
+        }
+        
+        SnpLzRow row = mock(SnpLzRow)
+        row.snpName.returns(snpProperties.snpName).stub()
+        row.chromosome.returns(snpProperties.chromosome).stub()
+        row.position.returns(snpProperties.position).stub()
+        row.a1.returns(snpProperties.a1).stub()
+        row.a2.returns(snpProperties.a2).stub()
+        
+        cells.eachWithIndex { cell, i ->
+            row.getAtPatientIndex(i).returns(cell).stub()
+        }
+        row.iterator().returns(cells.iterator()).stub()
+        
+        row
+    }
+
+}

--- a/test/unit/org/transmartproject/export/TFAMExporterTests.groovy
+++ b/test/unit/org/transmartproject/export/TFAMExporterTests.groovy
@@ -1,0 +1,88 @@
+package org.transmartproject.export
+
+import org.apache.commons.logging.LogFactory
+import org.gmock.WithGMock
+import org.junit.Before
+import org.junit.Test
+import org.transmartproject.core.dataquery.DataRow
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+
+/**
+ * Tests for the TFAM exporter in {@link TFAMExporter}
+ * 
+ * Generates mock data for the data types provided by {@link SnpSubjectModule}
+ * and tests if valid TFAM output is written, i.e., one line per subject. 
+ * The format has six columns for subject data. Only the first two are used:
+ * <code>familyId</code> and <code>individualId</code>.
+ * 
+ * @author gijs@thehyve.nl
+ */
+@WithGMock
+class TFAMExporterTests {
+
+    private static final log = LogFactory.getLog(this)
+    
+    @Delegate
+    SNPMockDataHelper snpMockDataHelper
+    
+    TFAMExporter exporter
+    TabularResult tabularResult
+    Map subjects
+    Projection projection
+    
+    Map<String, Map> snpProperties
+    Map<String, List> cellData
+    
+    @Before
+    void before() {
+        snpMockDataHelper = new SNPMockDataHelper()
+        snpMockDataHelper.gMockController = $gmockController
+        
+        // Setup exporter
+        exporter = new TFAMExporter()
+    }
+    
+    @Test
+    void "test whether supported datatypes are recognized"() {
+        // Only SNP subject datatype is supported
+        assert exporter.isDataTypeSupported( "snp_lz" )
+        
+        assert !exporter.isDataTypeSupported( "other" )
+        assert !exporter.isDataTypeSupported( null )
+    }
+    
+    @Test
+    void "test whether a basic tabular result is exported properly"() {
+        tabularResult = createMockSnpLzTabularResult()
+        subjects = createMockSubjectData()
+        
+        log.debug "subjects: $subjects"
+        
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        
+        play {
+            List<AssayColumn> assays = tabularResult.getIndicesList()
+            exporter.export( assays, subjects, outputStream )
+            
+            // Assert we have at least some text, in UTF-8 encoding
+            String output = outputStream.toString("UTF-8")
+            assert output
+            
+            List lines = output.readLines()
+            
+            lines.eachWithIndex { String line, i -> 
+                log.debug "Line: " + line
+                def values = line.tokenize()
+                assert values.size() == 6
+                def familyId = values[0]
+                def individualId = values[1]
+                def subject = subjectData[i]
+                assert subject.subjectId == familyId        // subjectId is used for the familyId field
+                assert subject.subjectId == individualId    // subjectId is used for the individualId field
+            }
+        }
+    }
+    
+}

--- a/test/unit/org/transmartproject/export/TPEDExporterTests.groovy
+++ b/test/unit/org/transmartproject/export/TPEDExporterTests.groovy
@@ -1,0 +1,91 @@
+package org.transmartproject.export
+
+import org.apache.commons.logging.LogFactory
+import org.gmock.WithGMock
+import org.junit.Before
+import org.junit.Test
+import org.transmartproject.core.dataquery.DataRow
+import org.transmartproject.core.dataquery.TabularResult
+import org.transmartproject.core.dataquery.highdim.AssayColumn
+import org.transmartproject.core.dataquery.highdim.projections.Projection
+
+/**
+ * Tests for the TPED exporter in {@link TPEDExporter}
+ * 
+ * Generates mock data for the data types provided by {@link SnpLzModule}
+ * and tests if valid TPED output is written, i.e., one line per 
+ * Single Nucleotide Polymorphism (SNP). 
+ * The format has four columns for information about the SNP, and 
+ * per subject two columns for alleles, stored as <code>likelyAllele1</code> 
+ * and <code>likelyAllele2</code> respectively in {@link SnpLzCell}.
+ * 
+ * @author gijs@thehyve.nl
+ */
+@WithGMock
+class TPEDExporterTests {
+
+    private static final log = LogFactory.getLog(this)
+    
+    @Delegate
+    SNPMockDataHelper snpMockDataHelper
+    
+    TPEDExporter exporter
+    TabularResult tabularResult
+    Projection projection
+    
+    Map<String, Map> snpProperties
+    Map<String, List> cellData
+    
+    @Before
+    void before() {
+        snpMockDataHelper = new SNPMockDataHelper()
+        snpMockDataHelper.gMockController = $gmockController
+        
+        // Setup exporter
+        exporter = new TPEDExporter()
+    }
+    
+    @Test
+    void "test whether supported datatypes are recognized"() {
+        // Only SNP datatype is supported
+        assert exporter.isDataTypeSupported( "snp_lz" )
+        
+        assert !exporter.isDataTypeSupported( "other" )
+        assert !exporter.isDataTypeSupported( null )
+    }
+    
+    @Test
+    void "test whether a basic tabular result is exported properly"() {
+        tabularResult = createMockSnpLzTabularResult()
+        
+        // Create cohort projection, as that is used for exporting.
+        def projection = mock(Projection)
+        
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        
+        play {
+            exporter.export( tabularResult, projection, outputStream )
+            
+            // Assert we have at least some text, in UTF-8 encoding
+            String output = outputStream.toString("UTF-8")
+            assert output
+            
+            List lines = output.readLines()
+            
+            lines.each { String line -> 
+                log.debug "Line: " + line
+                def values = line.tokenize()
+                assert values.size() == 4 + 2 * subjectCount // four columns for SNP info + two alleles per subject
+                def chromosome = values[0]
+                def snpId = values[1]
+                def position = values[3]
+                def snpKey = snpProperties.find { it.value.snpName == snpId }.key
+                cellData[snpKey].eachWithIndex { cell, i ->
+                    assert cell.likelyAllele1 == values[4 + i*2]
+                    assert cell.likelyAllele2 == values[4 + i*2 + 1]
+                }
+            }
+        }
+    }
+    
+}


### PR DESCRIPTION
Added exporters for SnpLz and SnpSubject using
the TPED/TFAM and the GEN/SAMPLE formats.

Depends on the changes in the snp-export branch of https://github.com/thehyve/naa-transmart-core-db.
