### PR TITLE
Don't require a `scope` OAuth url parameter

### DIFF
--- a/grails-app/controllers/OauthAdminController.groovy
+++ b/grails-app/controllers/OauthAdminController.groovy
@@ -74,6 +74,8 @@ class OauthAdminController {
             return
         }
         
+        client.scopes = ["_notused_"]
+
         params.clientSecret = params.clientSecret?.trim()
         if (!params.clientSecret) {
             params.remove('clientSecret')


### PR DESCRIPTION
We don't use the `scope` feature of OAuth at the moment. However there is a check in
spring security oauth2 that rejects authentication requests for clients that do not
have a scope parameter in either the Client registration info or in the url request.

Work around this check by setting a dummy scope when registering new clients.
