### PR TITLE
Validate filter input, disable 'Apply' button if invalid.

### DIFF
--- a/grails-app/services/com/recomdata/transmart/data/export/ExportMetadataService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/ExportMetadataService.groovy
@@ -218,6 +218,7 @@ class ExportMetadataService {
                 dataTypeName: highDimRow.datatype.dataTypeDescription,
                 isHighDimensional: true,
                 metadataExists: true,
+                supportedDataConstraints: highDimRow.datatype.supportedDataConstraints,
                 
                 subset1: exporters.collect {
                     [

--- a/grails-app/views/datasetExplorer/datasetExplorer.gsp
+++ b/grails-app/views/datasetExplorer/datasetExplorer.gsp
@@ -253,7 +253,8 @@
             <p id="filterKeywordDescription[chromosome_segment]" class="text filter_keyword_description">
                 Please provide one or multiple genomic region (separated by commas) in the format:
                 &lsquo;<var class="var">C</var><code>:</code><var class="var">start</var><code>-</code><var class="var">end</var>&rsquo;,
-                e.g., <code>X:1-1000000, 3:200000-400000</code>.
+                where <var class="var">C</var> is in the range 1&ndash;22 or one of <code>X</code>, <code>Y</code>, <code>XY</code>, <code>M</code>, <code>MT</code>.
+                E.g., <code>X:1-1000000, 3:200000-400000</code>.
             </p>
 
             <!-- Allow form submission with keyboard without duplicating the dialog button -->

--- a/grails-app/views/datasetExplorer/datasetExplorer.gsp
+++ b/grails-app/views/datasetExplorer/datasetExplorer.gsp
@@ -234,14 +234,27 @@
     <form id="filterForm">
         <fieldset>
             <label for="filterType">Filter Type</label>
-            <select id="filterType" onchange="HighDimensionDialogService.createAutocompleteInput();" >
+            <select id="filterType" onchange="HighDimensionDialogService.showKeywordDescription(); HighDimensionDialogService.createAutocompleteInput();" >
                 <option value="snps">SNP identifiers</option>
                 <option value="genes">Genes</option>
                 <option value="chromosome_segment">Genomic region</option>
             </select>
             <label for="filterKeyword">Keyword</label>
             <input type="text" name="filterKeyword" id="filterKeyword" value="" class="text ui-widget-content ui-corner-all">
-            <p id="filterKeywordFeedback" class="text warning"></p>
+            <p id="filterKeywordFeedback" class="text warning">No valid filter specification.</p>
+            <p id="filterKeywordDescription[snps]" class="text filter_keyword_description">
+                Please provide one or multiple SNP identifiers (separated by commas), e.g.,
+                <code>rs12890222, rs1234567</code>.
+            </p>
+            <p id="filterKeywordDescription[genes]" class="text filter_keyword_description">
+                Please provide one or multiple gene names (separated by commas), e.g.,
+                <code>TP53, AURKA</code>.
+            </p>
+            <p id="filterKeywordDescription[chromosome_segment]" class="text filter_keyword_description">
+                Please provide one or multiple genomic region (separated by commas) in the format:
+                &lsquo;<var class="var">C</var><code>:</code><var class="var">start</var><code>-</code><var class="var">end</var>&rsquo;,
+                e.g., <code>X:1-1000000, 3:200000-400000</code>.
+            </p>
 
             <!-- Allow form submission with keyboard without duplicating the dialog button -->
             <input type="button" tabindex="-1" style="position:absolute; top:-1000px">

--- a/grails-app/views/datasetExplorer/datasetExplorer.gsp
+++ b/grails-app/views/datasetExplorer/datasetExplorer.gsp
@@ -241,9 +241,10 @@
             </select>
             <label for="filterKeyword">Keyword</label>
             <input type="text" name="filterKeyword" id="filterKeyword" value="" class="text ui-widget-content ui-corner-all">
+            <p id="filterKeywordFeedback" class="text warning"></p>
 
             <!-- Allow form submission with keyboard without duplicating the dialog button -->
-            <input type="submit" tabindex="-1" style="position:absolute; top:-1000px">
+            <input type="button" tabindex="-1" style="position:absolute; top:-1000px">
         </fieldset>
     </form>
 </div>

--- a/grails-app/views/datasetExplorer/datasetExplorer.gsp
+++ b/grails-app/views/datasetExplorer/datasetExplorer.gsp
@@ -229,15 +229,15 @@
 
 
 %{--High Dimension Dialog--}%
-<div id="dialog-form" title="SNP Filtering">
-    <div id="loadingPleaseWait">Loading please wait ..</div>
+<div id="dialog-form" title="Filter data">
+    <div id="loadingPleaseWait">Loading, please wait...</div>
     <form id="filterForm">
         <fieldset>
             <label for="filterType">Filter Type</label>
             <select id="filterType" onchange="HighDimensionDialogService.createAutocompleteInput();" >
-                <option value="snps">SNP Identifiers</option>
+                <option value="snps">SNP identifiers</option>
                 <option value="genes">Genes</option>
-                <option value="chromosome_segment">Genomic Region</option>
+                <option value="chromosome_segment">Genomic region</option>
             </select>
             <label for="filterKeyword">Keyword</label>
             <input type="text" name="filterKeyword" id="filterKeyword" value="" class="text ui-widget-content ui-corner-all">

--- a/web-app/css/datasetExplorer.css
+++ b/web-app/css/datasetExplorer.css
@@ -558,3 +558,11 @@ li.x-tab-strip-active {
 
 .x-grid3-row .conceptUnselected, .x-grid3-row .conceptSelected {padding: 0 0 5px 5px; font-size: .85em;}
 .data-export-filter-tip {color: #666; font-style: italic}
+
+.var {
+    font-style: italic;
+}
+
+.warning {
+    color: #f77;
+}

--- a/web-app/css/datasetExplorer.css
+++ b/web-app/css/datasetExplorer.css
@@ -564,5 +564,6 @@ li.x-tab-strip-active {
 }
 
 .warning {
+    font-style: italic;
     color: #f77;
 }

--- a/web-app/js/datasetExplorer/exportData/dataExport.js
+++ b/web-app/js/datasetExplorer/exportData/dataExport.js
@@ -20,7 +20,7 @@ var DataExport = function() {
             url : pageInfo.basePath+'/dataExport/getMetaData',
             root : 'exportMetaData',
             fields : ['subsetId1', 'subsetName1', 'subset1', 'subsetId2', 'subsetName2', 'subset2', 'dataTypeId',
-                'dataTypeName', 'metadataExists']
+                'dataTypeName', 'metadataExists', 'supportedDataConstraints']
         });
         ret.proxy.addListener('loadexception', function(dummy, dummy2, response) {
             if (response.status != 200) {

--- a/web-app/js/datasetExplorer/highDimDialog.js
+++ b/web-app/js/datasetExplorer/highDimDialog.js
@@ -17,7 +17,7 @@ HighDimensionDialogService = (function(autocompleteInp) {
                 'chromosome': _strChrPos[0],
                 'start': _pos[0],
                 'end': _pos[1]
-            }
+            };
         };
 
         var _filter = {
@@ -27,13 +27,13 @@ HighDimensionDialogService = (function(autocompleteInp) {
 
         if (filterType === 'genes' || filterType === 'snps') {
             filterKeyword.split(_separator).forEach(function(d) {
-            	var _d = d.trim();
+                var _d = d.trim();
                 if (_d) {
-                	_filter.data.push(_d);
+                    _filter.data.push(_d);
                 }
             });
             _filter.names = _filter.data;
-        } else if (filterType === 'chromosome_segment' ) {
+        } else if (filterType === 'chromosome_segment') {
             filterKeyword.split(_separator).forEach(function(chrPos) {
                 _filter.data.push(_tokenizeChrPosition(chrPos.trim()));
             });
@@ -159,8 +159,8 @@ HighDimensionDialogService = (function(autocompleteInp) {
             _s.filterKeyword.val('');
             _s.applyBtn.button('disable');
             if (_s.filterType.val() !== 'snps') {
-            	_s.filterType.val('snps');
-            	_s.createAutocompleteInput();
+                _s.filterType.val('snps');
+                _s.createAutocompleteInput();
             }
             _s.filterType.prop('disabled', true);
 
@@ -171,7 +171,7 @@ HighDimensionDialogService = (function(autocompleteInp) {
 
             _s.filterForm.off('keypress');
             _s.filterForm.on('keypress', function(evt) {
-                if (evt.which == 13) {
+                if (evt.which === 13) {
                     evt.preventDefault();
                     if (!_s.applyBtn.prop('disabled')) {
                         _s.applyBtn.click();
@@ -222,11 +222,11 @@ HighDimensionDialogService = (function(autocompleteInp) {
      * and an error message is written to the <code>filterKeywordFeedback</code> element.
      */
     service.validateKeyword = function() {
-        		if (service.filterType.val() === 'chromosome_segment') {
+            if (service.filterType.val() === 'chromosome_segment') {
             // validate pattern
             var valid = false;
             var m = service.chromosome_segment_pattern
-                    .exec(service.filterKeyword.val())
+                    .exec(service.filterKeyword.val());
             if (m) {
                 var chromosome = m[1];
                 var start = m[2];
@@ -264,12 +264,12 @@ HighDimensionDialogService = (function(autocompleteInp) {
                 // filter not supported, disable filter
                 console.log('disable filter option: ' + val);
                 jQuery(this).prop('disabled', true);
-                if (selected == val) {
+                if (selected === val) {
                     selected = '';
                 }
             } else {
                 jQuery(this).prop('disabled', false);
-                if (selected == '') {
+                if (selected === '') {
                     selected = val;
                 }
             }
@@ -303,13 +303,13 @@ HighDimensionDialogService = (function(autocompleteInp) {
 
             _s.filterKeyword.off('keyup');
             _s.filterKeyword.on('keyup', function(evt) {
-        		_s.validateKeyword();
+                _s.validateKeyword();
             });
 
             _s.filterForm.off('keypress');
             _s.filterForm.on('keypress', function(evt) {
                 console.log('keypress: ' + evt.which);
-                if (evt.which == 13) {
+                if (evt.which === 13) {
                     evt.preventDefault();
                     if (!_s.applyBtn.prop('disabled')) {
                         _s.applyBtn.click();
@@ -399,8 +399,9 @@ HighDimensionDialogService = (function(autocompleteInp) {
         var shortname = "";
         if (splits.length > 1) {
             shortname = "...\\" + splits[splits.length - 2] + "\\" + splits[splits.length - 1];
+        } else {
+            shortname = splits[splits.length - 1];
         }
-        else shortname = splits[splits.length - 1];
         li.setAttribute('conceptshortname', shortname);
 
         //Create a setvalue description

--- a/web-app/js/datasetExplorer/highDimDialog.js
+++ b/web-app/js/datasetExplorer/highDimDialog.js
@@ -51,7 +51,6 @@ HighDimensionDialogService = (function(autocompleteInp) {
      */
     var _isCorrectHD = function (data, gridRow) {
         var _keys = Object.keys(data);
-        console.log(_keys);
         return _keys[0] === gridRow.dataTypeId;
     };
 
@@ -255,7 +254,29 @@ HighDimensionDialogService = (function(autocompleteInp) {
             }
             service.filterKeywordFeedback.text('');
         }
-    }
+    };
+
+    service.disableUnsupportedFilters = function(supportedDataConstraints) {
+        var selected = service.filterType.val();
+        service.filterType.find('option').each(function() {
+            var val = jQuery(this).val();
+            if (supportedDataConstraints.indexOf(val) == -1) {
+                // filter not supported, disable filter
+                console.log('disable filter option: ' + val);
+                jQuery(this).prop('disabled', true);
+                if (selected == val) {
+                    selected = '';
+                }
+            } else {
+                jQuery(this).prop('disabled', false);
+                if (selected == '') {
+                    selected = val;
+                }
+            }
+        });
+        service.filterType.val(selected);
+        console.log('selected filter type: ' + service.filterType.val());
+    };
 
     /**
      * Generate jQuery UI High Dimensional filter by identifier dialog
@@ -304,22 +325,25 @@ HighDimensionDialogService = (function(autocompleteInp) {
                 .done(function (d) {
                     dropzone.dropData.details = d;
                     if (_isCorrectHD(d, dropzone.recordData)) {
+                        console.log('show filter dialog for filter types: ', dropzone.recordData.supportedDataConstraints);
+                        _s.disableUnsupportedFilters(dropzone.recordData.supportedDataConstraints);
                         _s.filterForm.show();
                         _s.loadingEl.hide();
                         _s.cancelBtn.button('enable');
                         _s.createAutocompleteInput();
                     } else {
-                        _s.dialogEl.dialog("close");
+                        jQuery('#dialog-form').dialog('close');
                     }
                 })
                 .fail(function (msg) {
                     console.error('Something wrong when checking the node ...', msg);
-                    _s.dialogEl.dialog("close");
+                    jQuery('#dialog-form').dialog('close');
                 });
         };
 
         // assign close dialog handler
         _s.uiComponent.close = function () {
+            console.log('uiComponent.close');
             if (Object.keys(dropzone.dropData.details).indexOf(dropzone.recordData.dataTypeId) >= 0 ) {
                 dropzone.dropData.node.attributes.oktousevalues = "N";
                 _s.createPanelItemNew(dropzone.el, convertNodeToConcept(dropzone.dropData.node), dropzone.filter);

--- a/web-app/js/datasetExplorer/highDimDialog.js
+++ b/web-app/js/datasetExplorer/highDimDialog.js
@@ -216,19 +216,20 @@ HighDimensionDialogService = (function(autocompleteInp) {
 
     /**
      * The format used for specifying genomic regions: '<var>C</var>:<var>start</var>:<var>end</var>',
-     * where C is a chromosome number or any of <code>{'X', 'Y', 'XY', 'MT'}</code>.
+     * where C is a chromosome number in the range 1--22 or any of <code>{'X', 'Y', 'XY', 'M', 'MT'}</code>
+     * (assumes the human genome).
      * <var>start</var> and <var>end</var> are integers that specify an interval of basepair positions
      * in the chromosome.
      * Examples: <code>X:1-1000000</code>, <code>3:200000-400000</code>.
      */
-    service.chromosome_segment_pattern = /^([0-9]{1,2}|X|Y|XY|MT):(\d+)-(\d+)$/;
+    service.chromosome_segment_pattern = /^([0-9]{1,2}|X|Y|XY|M|MT):(\d+)-(\d+)$/;
 
     /**
      * Validates if the value in <var>filterKeyword</var> is conform the filter type
      * selected in <var>filterType</var>.
      * In particular, for chromosome segment, checks if the value matches the pattern in
-     * <var>chromosome_segment_pattern</var> and if the <var>start</var> values is smaller than (or equal to)
-     * the <var>end</var> value.
+     * <var>chromosome_segment_pattern</var>, if the chromosome number is in the range 1--22 (assuming the human genome),
+     * and if the <var>start</var> values is smaller than (or equal to) the <var>end</var> value.
      * If the <var>filterKeyword</var> conforms to the filter type format,
      * the <code>applyBtn</code> button is enabled; otherwise the button is disabled
      * and an error message is written to the <code>filterKeywordFeedback</code> element.
@@ -250,7 +251,8 @@ HighDimensionDialogService = (function(autocompleteInp) {
                             var chromosome = m[1];
                             var start = m[2];
                             var end = m[3];
-                            if (start <= end) {
+                            if ((isNaN(chromosome) || (chromosome >= 1 && chromosome <= 22))
+                                    && start <= end) {
                                 valid_segment = true;
                             }
                         }


### PR DESCRIPTION
- Validates filter input: checks if gene name, or
  SNP name are not empty and if a genomic region
  conforms to the required format;
- Gives feedback on the genomic region input;
- Disables 'apply' button until the filter input is
  valid;
- Disables default behaviour of pressing 'Enter'
  (submitting the form) and triggers a click event
  on the 'apply' button instead if enabled.
- Fixes dropping of low-dimensional data concepts in
  the data export.

Fixes NAA-63, NAA-70, NAA-75 and part of NAA-74.
