### PR TITLE
Fixed the titles in summary statistics for SNP data.

### DIFF
--- a/grails-app/services/org/transmartproject/HighDimChartDataService.groovy
+++ b/grails-app/services/org/transmartproject/HighDimChartDataService.groovy
@@ -75,7 +75,7 @@ class HighDimChartDataService {
      *
      * @param dataType highdim data type
      */
-    Map getBarChartData(
+    Map<String, Map> getBarChartData(
                 String dataType,
                 Map assayConstraintsSpec,
                 List filters) {
@@ -101,26 +101,17 @@ class HighDimChartDataService {
         TabularResult tabularResult = typeResource.retrieveData(
                 assayConstraints, [dataConstraints], projection)
 
-        List<Map> barChartData = []
-        Set<String> labels = []
+        Map<String, Map> barChartData = [:]
         try {
             for (Object row: tabularResult) {
-                if (!metadata) {
-                    metadata = getBarChartMetadataForDatatype(typeResource, row)
-                }
                 Map rowData = transformRow(row)
-                labels.addAll(rowData.keySet())
-                barChartData.add(rowData)
+                barChartData[row.label] = [title: row.label, labels: rowData.keySet(), data: rowData]
             }
         } finally {
             tabularResult.close() //closing the tabular result, no matter what
         }
 
-        [
-            title: metadata.title,
-            labels: labels,
-            data: barChartData
-        ]
+        barChartData
     }
 
     /**


### PR DESCRIPTION
Fixed the titles of tables and plots in summary
statistics for high dimensional data.
Previously all charts for a data type would get the
same title, instead of the row label.

Fixes NAA-84.
