### PR TITLE
Fix the order of columns in column export.

### DIFF
--- a/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
+++ b/grails-app/services/com/recomdata/transmart/data/export/HighDimExportService.groovy
@@ -132,11 +132,8 @@ class HighDimExportService {
             exporter = exporter as HighDimColumnExporter
             def startTime = System.currentTimeMillis()
             log.debug "Fetching assays..."
-            Map<HighDimensionDataTypeResource, Collection<Assay>> assayMap = highDimensionResourceService.getSubResourcesAssayMultiMap(assayconstraints)
+            List<AssayColumn> assays = dataTypeResource.retrieveAssays(assayconstraints)
             log.debug "Fetching assays took ${System.currentTimeMillis() - startTime} ms."
-            // for some reason, this dataTypeResourceKey is not the same as dataTypeResource:
-            def dataTypeResourceKey = assayMap.keySet().find { it.dataTypeName == dataTypeResource.dataTypeName }
-            Collection<Assay> assays = assayMap[dataTypeResourceKey]
             // Start exporting column data
             outputFile.withOutputStream { outputStream ->
                 result = exporter.export assays, outputStream, { jobIsCancelled(jobName) }

--- a/src/groovy/org/transmartproject/export/HighDimColumnExporter.groovy
+++ b/src/groovy/org/transmartproject/export/HighDimColumnExporter.groovy
@@ -35,7 +35,7 @@ interface HighDimColumnExporter extends HighDimExporter {
      * @return a map with information about the exported values:
      *      the entry with key <code>rowsWritten</code> contains the number of rows written.
      */
-    public Map<String, Object> export( Collection<Assay> assays, OutputStream outputStream )
+    public Map<String, Object> export( List<Assay> assays, OutputStream outputStream )
 
     /**
      * Exports column data to the outputStream,
@@ -47,6 +47,6 @@ interface HighDimColumnExporter extends HighDimExporter {
      * @return a map with information about the exported values:
      *      the entry with key <code>rowsWritten</code> contains the number of rows written.
      */
-    public Map<String, Object> export( Collection<Assay> assays, OutputStream outputStream, Closure isCancelled )
+    public Map<String, Object> export( List<Assay> assays, OutputStream outputStream, Closure isCancelled )
 
 }

--- a/src/groovy/org/transmartproject/export/SAMPLEExporter.groovy
+++ b/src/groovy/org/transmartproject/export/SAMPLEExporter.groovy
@@ -57,13 +57,13 @@ class SAMPLEExporter implements HighDimColumnExporter {
     }
 
     @Override
-    public Map<String, Object> export(Collection<Assay> assays,
+    public Map<String, Object> export(List<Assay> assays,
             OutputStream outputStream) {
         export(assays, outputStream, { false })
     }
 
     @Override
-    public Map<String, Object> export(Collection<Assay> assays,
+    public Map<String, Object> export(List<Assay> assays,
             OutputStream outputStream, Closure isCancelled) {
         log.info "Started exporting to ${format}..."
         def startTime = System.currentTimeMillis()
@@ -74,7 +74,7 @@ class SAMPLEExporter implements HighDimColumnExporter {
 
         long i = 0
 
-        outputStream.withWriter( "UTF-8" ) { out ->
+        outputStream.withWriter( "UTF-8" ) { Writer out ->
             exportHeader(out)
             
             for (Assay assay: assays) {

--- a/src/groovy/org/transmartproject/export/TFAMExporter.groovy
+++ b/src/groovy/org/transmartproject/export/TFAMExporter.groovy
@@ -54,7 +54,7 @@ class TFAMExporter implements HighDimColumnExporter {
         
         int value
         
-        TFAM_Phenotype(value) {
+        TFAM_Phenotype(int value) {
             this.value = value
         }
     }
@@ -99,13 +99,13 @@ class TFAMExporter implements HighDimColumnExporter {
     }
 
     @Override
-    public Map<String, Object> export(Collection<Assay> assays,
+    public Map<String, Object> export(List<Assay> assays,
             OutputStream outputStream) {
         export(assays, outputStream, { false })
     }
 
     @Override
-    public Map<String, Object> export(Collection<Assay> assays,
+    public Map<String, Object> export(List<Assay> assays,
             OutputStream outputStream, Closure isCancelled) {
         log.info "Started exporting to ${format}..."
         def startTime = System.currentTimeMillis()
@@ -116,7 +116,7 @@ class TFAMExporter implements HighDimColumnExporter {
 
         long i = 0
 
-        outputStream.withWriter( "UTF-8" ) { out ->
+        outputStream.withWriter( "UTF-8" ) { Writer out ->
             for (Assay assay: assays) {
                 if (isCancelled() ) {
                     return


### PR DESCRIPTION
The order in assays in column exports (export of
assay data, as in the SAMPLE and TFAM formats),
should correspond to the assay order as used in the
high dimensional data exports.
A new function has been added to high dimensional
data types that retrieves assay columns in the correct
order.

Depends on https://github.com/thehyve/naa-transmart-core-api/pull/3, https://github.com/thehyve/naa-transmart-core-db/pull/13.
